### PR TITLE
Bug: Add `Sync.Mutex` Lock to Prevent Data Races 

### DIFF
--- a/internal/camera.go
+++ b/internal/camera.go
@@ -20,7 +20,9 @@ func (s *Server) HandleCameraReq(conn net.Conn, reader *bufio.Reader, clientType
 
 	// register camera
 	log.Printf("[%s] Camera: Recived %v\n", conn.RemoteAddr().String(), camera)
+	s.slock.Lock()
 	s.cameras[conn] = camera
+	s.slock.Unlock()
 	*clientType = CAMERA
 
 	return

--- a/internal/camera.go
+++ b/internal/camera.go
@@ -40,7 +40,9 @@ func (s *Server) HandlePlateReq(conn net.Conn, reader *bufio.Reader, client *Cli
 		return
 	}
 
+	s.slock.Lock()
 	cam, ok := s.cameras[conn]
+	s.slock.Unlock()
 	if !ok {
 		log.Printf("Camera not found\n")
 		return

--- a/internal/dispatcher.go
+++ b/internal/dispatcher.go
@@ -21,7 +21,9 @@ func (s *Server) HandleDispatcherReq(conn net.Conn, reader *bufio.Reader, client
 	}
 
 	log.Printf("[%s] Dispatcher Recived %v\n", conn.RemoteAddr().String(), d)
+	s.slock.Lock()
 	s.dispatchers[conn] = d
+	s.slock.Unlock()
 	*client = DISPATCHER
 
 	err = s.checkPendingTickets(conn, d)

--- a/internal/server.go
+++ b/internal/server.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"sync"
 )
 
 type Server struct {
@@ -16,6 +17,7 @@ type Server struct {
 	cameras       map[net.Conn]Camera
 	dispatchers   map[net.Conn]Dispatcher
 	pending_queue []Ticket
+	slock         sync.RWMutex
 }
 
 func NewServer(addr string, store Store) *Server {
@@ -92,9 +94,13 @@ func (s *Server) CleanUpClient(conn net.Conn, client *ClientType) {
 	defer conn.Close()
 	switch *client {
 	case CAMERA:
+		s.slock.Lock()
 		delete(s.cameras, conn)
+		s.slock.Unlock()
 	case DISPATCHER:
+		s.slock.Lock()
 		delete(s.dispatchers, conn)
+		s.slock.Unlock()
 	}
 }
 


### PR DESCRIPTION
This pull request introduces thread safety improvements and optimizations for handling observations in the server code. The most important changes include adding a read-write mutex for camera and dispatcher maps, ensuring proper locking and unlocking mechanisms, and optimizing the handling of prior observations in speed detection.

Thread safety improvements:

* [`internal/server.go`](diffhunk://#diff-2b0bf79e19fe4eb1540beb0b6d88642e3c87ab38de6103290a4e4f775e377173R20): Added a read-write mutex `slock` to the `Server` struct and used it to lock and unlock access to the `cameras` and `dispatchers` maps in the `HandleCameraReq` and `CleanUpClient` methods. [[1]](diffhunk://#diff-2b0bf79e19fe4eb1540beb0b6d88642e3c87ab38de6103290a4e4f775e377173R20) [[2]](diffhunk://#diff-9443396a6a767d619bf3e26fad2fdd7f9ce3f758d322c9a9f64e4a5ffd63eddaR23-R25) [[3]](diffhunk://#diff-2b0bf79e19fe4eb1540beb0b6d88642e3c87ab38de6103290a4e4f775e377173R97-R103)

Optimizations for handling observations:

* [`internal/speed_detection.go`](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dL10-R14): Optimized the `handleSpeedViolations` method by storing the result of `s.store.GetObservations(obs.Plate)` in a variable `observations` to avoid multiple calls to the same method.

Other changes:

* [`internal/server.go`](diffhunk://#diff-2b0bf79e19fe4eb1540beb0b6d88642e3c87ab38de6103290a4e4f775e377173R9): Added the `sync` package import for using the read-write mutex.
* [`internal/speed_detection.go`](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dR59-R60): Added locking and unlocking around the dispatcher loop in the `DispatchTicket` method to ensure thread safety.