### PR TITLE
Fix: Locks Improvements, Logging and Error Handling 

### DIFF
--- a/internal/camera.go
+++ b/internal/camera.go
@@ -8,21 +8,6 @@ import (
 )
 
 func (s *Server) HandleCameraReq(conn net.Conn, reader *bufio.Reader, clientType *ClientType) error {
-	if *clientType != UNKNOWN {
-		return fmt.Errorf("[camera request] Client is already registered.")
-	}
-
-	buffered := reader.Buffered()
-	fmt.Printf("[%s] Buffered bytes available: %X\n", conn.RemoteAddr().String(), buffered)
-
-	// Peek at the data without consuming it
-	a, err := reader.Peek(buffered)
-	if err != nil {
-		fmt.Printf("Peek error: %v\n", err)
-	} else {
-		fmt.Printf("[%s] Peeked data: %x\n", conn.RemoteAddr().String(), a) // Print as hex
-	}
-
 	camera, err := ParseCameraRequest(reader)
 	if err != nil {
 		return fmt.Errorf("Failed to parse request %v", err)

--- a/internal/camera.go
+++ b/internal/camera.go
@@ -9,7 +9,7 @@ import (
 
 func (s *Server) HandleCameraReq(conn net.Conn, reader *bufio.Reader, clientType *ClientType) error {
 	if *clientType != UNKNOWN {
-		return fmt.Errorf("Client is already registered.")
+		return fmt.Errorf("[camera request] Client is already registered.")
 	}
 
 	camera, err := ParseCameraRequest(reader)
@@ -37,14 +37,14 @@ func (s *Server) HandlePlateReq(conn net.Conn, reader *bufio.Reader, client *Cli
 		return err
 	}
 
+	log.Printf("[%s] Plate Request Recieved %v", conn.RemoteAddr().String(), plate)
+
 	s.slock.Lock()
 	cam, ok := s.cameras[conn]
 	s.slock.Unlock()
 	if !ok {
 		return err
 	}
-
-	log.Printf("[%s] Plate Record Receieved: %v from Camera %v\n", conn.RemoteAddr().String(), plate, cam)
 
 	observation := Observation{Plate: plate.Plate, Road: cam.Road, Mile: cam.Mile, Timestamp: plate.Timestamp, Limit: cam.Limit}
 	s.store.AddObservation(observation)

--- a/internal/camera.go
+++ b/internal/camera.go
@@ -45,6 +45,8 @@ func (s *Server) HandlePlateReq(conn net.Conn, reader *bufio.Reader, client *Cli
 	observation := Observation{Plate: plate.Plate, Road: cam.Road, Mile: cam.Mile, Timestamp: plate.Timestamp, Limit: cam.Limit}
 	s.store.AddObservation(observation)
 
+	s.slock.Lock()
+	defer s.slock.Unlock()
 	err = s.handleSpeedViolations(conn, observation)
 	if err != nil {
 		return fmt.Errorf("Failed to Handle Plate Records: %v", err)

--- a/internal/camera.go
+++ b/internal/camera.go
@@ -12,6 +12,17 @@ func (s *Server) HandleCameraReq(conn net.Conn, reader *bufio.Reader, clientType
 		return fmt.Errorf("[camera request] Client is already registered.")
 	}
 
+	buffered := reader.Buffered()
+	fmt.Printf("[%s] Buffered bytes available: %X\n", conn.RemoteAddr().String(), buffered)
+
+	// Peek at the data without consuming it
+	a, err := reader.Peek(buffered)
+	if err != nil {
+		fmt.Printf("Peek error: %v\n", err)
+	} else {
+		fmt.Printf("[%s] Peeked data: %x\n", conn.RemoteAddr().String(), a) // Print as hex
+	}
+
 	camera, err := ParseCameraRequest(reader)
 	if err != nil {
 		return fmt.Errorf("Failed to parse request %v", err)

--- a/internal/camera.go
+++ b/internal/camera.go
@@ -33,14 +33,15 @@ func (s *Server) HandlePlateReq(conn net.Conn, reader *bufio.Reader, client *Cli
 		return err
 	}
 
-	log.Printf("[%s] Plate Request Recieved %v", conn.RemoteAddr().String(), plate)
-
 	s.slock.Lock()
 	cam, ok := s.cameras[conn]
-	s.slock.Unlock()
 	if !ok {
+		s.slock.Unlock()
 		return err
 	}
+	s.slock.Unlock()
+
+	log.Printf("[%s] Plate Request Recieved %v on Road %d Mile %d Limit %d", conn.RemoteAddr().String(), plate, cam.Road, cam.Mile, cam.Limit)
 
 	observation := Observation{Plate: plate.Plate, Road: cam.Road, Mile: cam.Mile, Timestamp: plate.Timestamp, Limit: cam.Limit}
 	s.store.AddObservation(observation)

--- a/internal/camera.go
+++ b/internal/camera.go
@@ -8,6 +8,10 @@ import (
 )
 
 func (s *Server) HandleCameraReq(conn net.Conn, reader *bufio.Reader, clientType *ClientType) error {
+	if *clientType != UNKNOWN {
+		return fmt.Errorf("Client is already registered.")
+	}
+
 	camera, err := ParseCameraRequest(reader)
 	if err != nil {
 		return fmt.Errorf("Failed to parse request %v", err)

--- a/internal/dispatcher.go
+++ b/internal/dispatcher.go
@@ -23,6 +23,8 @@ func (s *Server) HandleDispatcherReq(conn net.Conn, reader *bufio.Reader, client
 	s.dispatchers[conn] = d
 	*client = DISPATCHER
 
+	s.slock.Lock()
+	defer s.slock.Unlock()
 	err = s.checkPendingTickets(conn, d)
 	if err != nil {
 		return fmt.Errorf("Failed to parse request %v", err)

--- a/internal/dispatcher.go
+++ b/internal/dispatcher.go
@@ -10,7 +10,7 @@ import (
 
 func (s *Server) HandleDispatcherReq(conn net.Conn, reader *bufio.Reader, client *ClientType) error {
 	if *client != UNKNOWN {
-		return fmt.Errorf("Client is alredy registered on this connection")
+		return fmt.Errorf("[dispatcher] Client is alredy registered on this connection")
 	}
 
 	d, err := ParseDispatcherRecord(reader)

--- a/internal/dispatcher.go
+++ b/internal/dispatcher.go
@@ -19,9 +19,10 @@ func (s *Server) HandleDispatcherReq(conn net.Conn, reader *bufio.Reader, client
 	}
 
 	log.Printf("[%s] Dispatcher Recived %v\n", conn.RemoteAddr().String(), d)
+
 	s.slock.Lock()
+	defer s.slock.Unlock()
 	s.dispatchers[conn] = d
-	s.slock.Unlock()
 	*client = DISPATCHER
 
 	err = s.checkPendingTickets(conn, d)

--- a/internal/dispatcher.go
+++ b/internal/dispatcher.go
@@ -20,8 +20,6 @@ func (s *Server) HandleDispatcherReq(conn net.Conn, reader *bufio.Reader, client
 
 	log.Printf("[%s] Dispatcher Recived %v\n", conn.RemoteAddr().String(), d)
 
-	s.slock.Lock()
-	defer s.slock.Unlock()
 	s.dispatchers[conn] = d
 	*client = DISPATCHER
 

--- a/internal/dispatcher.go
+++ b/internal/dispatcher.go
@@ -20,11 +20,12 @@ func (s *Server) HandleDispatcherReq(conn net.Conn, reader *bufio.Reader, client
 
 	log.Printf("[%s] Dispatcher Recived %v\n", conn.RemoteAddr().String(), d)
 
+	s.slock.Lock()
+	defer s.slock.Unlock()
+
 	s.dispatchers[conn] = d
 	*client = DISPATCHER
 
-	s.slock.Lock()
-	defer s.slock.Unlock()
 	err = s.checkPendingTickets(conn, d)
 	if err != nil {
 		return fmt.Errorf("Failed to parse request %v", err)

--- a/internal/heartbeat.go
+++ b/internal/heartbeat.go
@@ -9,10 +9,6 @@ import (
 )
 
 func (s *Server) WantHeatbeatHandler(conn net.Conn, reader *bufio.Reader, isHeartbeatRegistered *bool, client *ClientType) error {
-	if *client == UNKNOWN {
-		return fmt.Errorf("Client is not registered.")
-	}
-
 	if *isHeartbeatRegistered {
 		return fmt.Errorf("Heartbeat is already registered.")
 	}

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -62,7 +62,7 @@ func ParseCameraRequest(reader *bufio.Reader) (Camera, error) {
 	err := binary.Read(reader, binary.BigEndian, &data)
 
 	if err != nil {
-		return data, fmt.Errorf("Error Parsing CameraRequest %x", err)
+		return data, fmt.Errorf("Error Parsing CameraRequest %v", err)
 	}
 
 	return data, nil

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -58,19 +58,8 @@ func ParseString(reader *bufio.Reader) (string, error) {
 }
 
 func ParseCameraRequest(reader *bufio.Reader) (Camera, error) {
-	buffered := reader.Buffered()
-	fmt.Printf("Buffered bytes available: %d\n", buffered)
-
-	// Peek at the data without consuming it
-	a, err := reader.Peek(buffered)
-	if err != nil {
-		fmt.Printf("Peek error: %v\n", err)
-	} else {
-		fmt.Printf("Peeked data: %x\n", a) // Print as hex
-	}
-
 	var data Camera
-	err = binary.Read(reader, binary.BigEndian, &data)
+	err := binary.Read(reader, binary.BigEndian, &data)
 
 	if err != nil {
 		return data, fmt.Errorf("Error Parsing CameraRequest %v", err)

--- a/internal/protocol.go
+++ b/internal/protocol.go
@@ -58,8 +58,19 @@ func ParseString(reader *bufio.Reader) (string, error) {
 }
 
 func ParseCameraRequest(reader *bufio.Reader) (Camera, error) {
+	buffered := reader.Buffered()
+	fmt.Printf("Buffered bytes available: %d\n", buffered)
+
+	// Peek at the data without consuming it
+	a, err := reader.Peek(buffered)
+	if err != nil {
+		fmt.Printf("Peek error: %v\n", err)
+	} else {
+		fmt.Printf("Peeked data: %x\n", a) // Print as hex
+	}
+
 	var data Camera
-	err := binary.Read(reader, binary.BigEndian, &data)
+	err = binary.Read(reader, binary.BigEndian, &data)
 
 	if err != nil {
 		return data, fmt.Errorf("Error Parsing CameraRequest %v", err)

--- a/internal/server.go
+++ b/internal/server.go
@@ -71,7 +71,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	for {
 		msgType, err := ReadMsgType(reader)
 		if err != nil {
-			log.Printf("Connection Error: %v", err)
+			log.Printf("[%s] Connection Error: %v", conn.RemoteAddr().String(), err)
 			return
 		}
 

--- a/internal/server.go
+++ b/internal/server.go
@@ -17,7 +17,7 @@ type Server struct {
 	cameras       map[net.Conn]Camera
 	dispatchers   map[net.Conn]Dispatcher
 	pending_queue []Ticket
-	slock         sync.RWMutex
+	slock         sync.Mutex
 }
 
 func NewServer(addr string, store Store) *Server {

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"log"
 	"math"
 	"net"

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"log"
+	"math"
 	"net"
 	"slices"
 )
@@ -23,7 +24,7 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 		}
 
 		isSpeedViolation, speed := isSpeedViolation(obs1, obs2)
-		log.Printf("[%s] isSpeedViolation[%v] - %v\n with Obs2 %v", conn.RemoteAddr().String(), isSpeedViolation, speed, obs2)
+		log.Printf("[%s] isSpeedViolation[%v] - %v with obs1 %v and obs1", conn.RemoteAddr().String(), isSpeedViolation, speed, obs2)
 
 		if !isSpeedViolation {
 			continue
@@ -76,8 +77,8 @@ func (s *Server) SendTicket(conn net.Conn, ticket *Ticket) error {
 }
 
 func isSpeedViolation(obs1, obs2 Observation) (bool, uint16) {
-	distance := uint32(obs2.Mile - obs1.Mile)
-	time := obs2.Timestamp - obs1.Timestamp // unix timestamp -> seconds
+	distance := uint32(math.Abs(float64(obs2.Mile - obs1.Mile)))
+	time := uint32(math.Abs(float64(obs2.Timestamp - obs1.Timestamp))) // unix timestamp -> seconds
 	if time == 0 {
 		return false, 0
 	}

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -23,7 +23,7 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 		}
 
 		isSpeedViolation, speed := isSpeedViolation(obs1, obs2)
-		log.Printf("[%s] isSpeedViolation[%v] - %v\n", conn.RemoteAddr().String(), isSpeedViolation, speed)
+		log.Printf("[%s] isSpeedViolation[%v] - %v\n with Obs2 %v", conn.RemoteAddr().String(), isSpeedViolation, speed, obs2)
 
 		if !isSpeedViolation {
 			continue

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"slices"
 )
@@ -19,12 +20,8 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 
 		obs1 := preObs
 		obs2 := obs
-		if obs1.Mile > obs2.Mile {
+		if obs1.Timestamp > obs2.Timestamp {
 			obs1, obs2 = obs2, obs1
-		}
-
-		if obs2.Timestamp <= obs1.Timestamp {
-			return fmt.Errorf("Invalid: time must increase")
 		}
 
 		isSpeedViolation, speed := isSpeedViolation(obs1, obs2)
@@ -81,7 +78,7 @@ func (s *Server) SendTicket(conn net.Conn, ticket *Ticket) error {
 }
 
 func isSpeedViolation(obs1, obs2 Observation) (bool, uint16) {
-	distance := uint32(obs2.Mile - obs1.Mile)
+	distance := uint32(math.Abs(float64(obs2.Mile) - float64(obs1.Mile)))
 	time := obs2.Timestamp - obs1.Timestamp // unix timestamp -> seconds
 	if time == 0 {
 		return false, 0

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -98,8 +98,6 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 	day2 := ticket.Timestamp2 / 86400
 
 	// check one ticket per day
-	s.slock.Lock()
-	defer s.slock.Unlock()
 	priorPlateTickets := s.store.GetTickets(ticket.Plate)
 	log.Printf("[%s] Prior Plate Tickets [%s]: %v", conn.RemoteAddr().String(), ticket.Plate, priorPlateTickets)
 	for _, t := range priorPlateTickets {

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -107,7 +107,7 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 		log.Printf("day1 and day2 %d %d %d %d", day1, day2, t.Timestamp1, t.Timestamp2)
 		t1 := t.Timestamp1 / 86400
 		t2 := t.Timestamp2 / 86400
-		if t1 == day1 || day1 == t2 || day2 == t2 || day2 == t2 {
+		if t1 == day1 || day1 == t2 || day2 == t1 || day2 == t2 {
 			log.Printf("[%s] Ticket Already Exist for Timestamp [%d or %d]\n", conn.RemoteAddr().String(), day1, day2)
 			return false
 		}

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -1,8 +1,8 @@
 package server
 
 import (
+	"fmt"
 	"log"
-	"math"
 	"net"
 	"slices"
 )
@@ -21,6 +21,10 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 		obs2 := obs
 		if obs1.Mile > obs2.Mile {
 			obs1, obs2 = obs2, obs1
+		}
+
+		if obs2.Timestamp <= obs1.Timestamp {
+			return fmt.Errorf("Invalid: time must increase")
 		}
 
 		isSpeedViolation, speed := isSpeedViolation(obs1, obs2)
@@ -77,8 +81,8 @@ func (s *Server) SendTicket(conn net.Conn, ticket *Ticket) error {
 }
 
 func isSpeedViolation(obs1, obs2 Observation) (bool, uint16) {
-	distance := uint32(math.Abs(float64(obs2.Mile) - float64(obs1.Mile)))
-	time := uint32(math.Abs(float64(obs2.Timestamp) - float64(obs1.Timestamp))) // unix timestamp -> seconds
+	distance := uint32(obs2.Mile - obs1.Mile)
+	time := obs2.Timestamp - obs1.Timestamp // unix timestamp -> seconds
 	if time == 0 {
 		return false, 0
 	}

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -103,6 +103,7 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 	s.slock.Lock()
 	priorPlateTickets := s.store.GetTickets(ticket.Plate)
 	log.Printf("[%s] Prior Plate Tickets [%s]: %v", conn.RemoteAddr().String(), ticket.Plate, priorPlateTickets)
+	log.Printf("day1 and day2 %d %d", day1, day2)
 	for _, t := range priorPlateTickets {
 		if t.Timestamp1 == day1 || day1 == t.Timestamp2 || day2 == t.Timestamp1 || day2 == t.Timestamp2 {
 			log.Printf("[%s] Ticket Already Exist for Timestamp [%d or %d]\n", conn.RemoteAddr().String(), day1, day2)

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -96,7 +96,6 @@ func isSpeedViolation(obs1, obs2 Observation) (bool, uint16) {
 
 // implementing multi-day limit and with one limit per day
 func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
-	log.Printf("Checking Ticket Limit Daily")
 	day1 := ticket.Timestamp1 / 86400
 	day2 := ticket.Timestamp2 / 86400
 

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -103,8 +103,8 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 	s.slock.Lock()
 	priorPlateTickets := s.store.GetTickets(ticket.Plate)
 	log.Printf("[%s] Prior Plate Tickets [%s]: %v", conn.RemoteAddr().String(), ticket.Plate, priorPlateTickets)
-	log.Printf("day1 and day2 %d %d", day1, day2)
 	for _, t := range priorPlateTickets {
+		log.Printf("day1 and day2 %d %d %d %d", day1, day2, t.Timestamp1, t.Timestamp2)
 		if t.Timestamp1 == day1 || day1 == t.Timestamp2 || day2 == t.Timestamp1 || day2 == t.Timestamp2 {
 			log.Printf("[%s] Ticket Already Exist for Timestamp [%d or %d]\n", conn.RemoteAddr().String(), day1, day2)
 			return false

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -24,7 +24,7 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 		}
 
 		isSpeedViolation, speed := isSpeedViolation(obs1, obs2)
-		log.Printf("[%s] isSpeedViolation[%v] - %v with obs1 %v and obs1", conn.RemoteAddr().String(), isSpeedViolation, speed, obs2)
+		log.Printf("[%s] isSpeedViolation[%v] - %v", conn.RemoteAddr().String(), isSpeedViolation, speed)
 
 		if !isSpeedViolation {
 			continue
@@ -77,8 +77,8 @@ func (s *Server) SendTicket(conn net.Conn, ticket *Ticket) error {
 }
 
 func isSpeedViolation(obs1, obs2 Observation) (bool, uint16) {
-	distance := uint32(math.Abs(float64(obs2.Mile - obs1.Mile)))
-	time := uint32(math.Abs(float64(obs2.Timestamp - obs1.Timestamp))) // unix timestamp -> seconds
+	distance := uint32(math.Abs(float64(obs2.Mile) - float64(obs1.Mile)))
+	time := uint32(math.Abs(float64(obs2.Timestamp) - float64(obs1.Timestamp))) // unix timestamp -> seconds
 	if time == 0 {
 		return false, 0
 	}

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -19,7 +19,7 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 
 		obs1 := preObs
 		obs2 := obs
-		if obs1.Timestamp > obs2.Timestamp {
+		if obs1.Mile > obs2.Mile {
 			obs1, obs2 = obs2, obs1
 		}
 

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -96,6 +96,7 @@ func isSpeedViolation(obs1, obs2 Observation) (bool, uint16) {
 
 // implementing multi-day limit and with one limit per day
 func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
+	log.Printf("Checking Ticket Limit Daily")
 	day1 := ticket.Timestamp1 / 86400
 	day2 := ticket.Timestamp2 / 86400
 
@@ -104,7 +105,6 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 	priorPlateTickets := s.store.GetTickets(ticket.Plate)
 	log.Printf("[%s] Prior Plate Tickets [%s]: %v", conn.RemoteAddr().String(), ticket.Plate, priorPlateTickets)
 	for _, t := range priorPlateTickets {
-		log.Printf("day1 and day2 %d %d %d %d", day1, day2, t.Timestamp1, t.Timestamp2)
 		t1 := t.Timestamp1 / 86400
 		t2 := t.Timestamp2 / 86400
 		if t1 == day1 || day1 == t2 || day2 == t1 || day2 == t2 {

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -54,8 +54,6 @@ func (s *Server) handleSpeedViolations(conn net.Conn, obs Observation) error {
 func (s *Server) DispatchTicket(conn net.Conn, ticket *Ticket) error {
 	// check all active dispatcher
 	log.Printf("[%s] Dispatching Ticket [%v]\n", conn.RemoteAddr().String(), ticket)
-	s.slock.Lock()
-	defer s.slock.Unlock()
 	for c, disp := range s.dispatchers {
 		if slices.Contains(disp.Roads, ticket.Road) {
 			err := s.SendTicket(c, ticket)
@@ -101,6 +99,7 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 
 	// check one ticket per day
 	s.slock.Lock()
+	defer s.slock.Unlock()
 	priorPlateTickets := s.store.GetTickets(ticket.Plate)
 	log.Printf("[%s] Prior Plate Tickets [%s]: %v", conn.RemoteAddr().String(), ticket.Plate, priorPlateTickets)
 	for _, t := range priorPlateTickets {
@@ -111,7 +110,6 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 			return false
 		}
 	}
-	s.slock.Unlock()
 
 	return true
 }

--- a/internal/speed_detection.go
+++ b/internal/speed_detection.go
@@ -105,7 +105,9 @@ func (s *Server) CheckTicketLimit(conn net.Conn, ticket *Ticket) bool {
 	log.Printf("[%s] Prior Plate Tickets [%s]: %v", conn.RemoteAddr().String(), ticket.Plate, priorPlateTickets)
 	for _, t := range priorPlateTickets {
 		log.Printf("day1 and day2 %d %d %d %d", day1, day2, t.Timestamp1, t.Timestamp2)
-		if t.Timestamp1 == day1 || day1 == t.Timestamp2 || day2 == t.Timestamp1 || day2 == t.Timestamp2 {
+		t1 := t.Timestamp1 / 86400
+		t2 := t.Timestamp2 / 86400
+		if t1 == day1 || day1 == t2 || day2 == t2 || day2 == t2 {
 			log.Printf("[%s] Ticket Already Exist for Timestamp [%d or %d]\n", conn.RemoteAddr().String(), day1, day2)
 			return false
 		}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -32,7 +32,7 @@ func TestMain(t *testing.M) {
 }
 
 func TestHeartbeatErrorHandling(t *testing.T) {
-	cameras := []srv.Camera{{Road: 124, Mile: 8, Limit: 60}}
+	cameras := []srv.Camera{{Road: 121, Mile: 8, Limit: 60}}
 	c1 := SetupCameras(t, addr, cameras...)[0]
 
 	c1.SendWantHeartbeat(srv.WantHeartbeat{Interval: 0})
@@ -46,7 +46,7 @@ func TestHeartbeatErrorHandling(t *testing.T) {
 }
 
 func TestSimpleErrorHandling(t *testing.T) {
-	cameras := []srv.Camera{{Road: 124, Mile: 8, Limit: 60}}
+	cameras := []srv.Camera{{Road: 190, Mile: 8, Limit: 60}}
 	cameraClients := SetupCameras(t, addr, cameras...)
 	cameraClients[0].SendIAMCamera(srv.Camera{Road: 124, Mile: 8, Limit: 60})
 
@@ -133,14 +133,14 @@ func TestSimpleTicketGeneration(t *testing.T) {
 	defer ClientCleanUp(t, dispatcherClients...)
 
 	// Send Plate Observations
-	c1.SendPlateRecord(srv.Plate{Plate: "UN1X", Timestamp: 0})
-	c2.SendPlateRecord(srv.Plate{Plate: "UN1X", Timestamp: 45})
+	c1.SendPlateRecord(srv.Plate{Plate: "PLAT", Timestamp: 0})
+	c2.SendPlateRecord(srv.Plate{Plate: "PLAT", Timestamp: 45})
 
 	time.Sleep(2000 * time.Millisecond)
 
 	// assert the ticket
 	reader := bufio.NewReader(d1.Conn)
-	expectedTicket := srv.Ticket{Plate: "UN1X", Road: 123, Mile1: 8, Mile2: 9, Timestamp1: 0, Timestamp2: 45, Speed: 8000}
+	expectedTicket := srv.Ticket{Plate: "PLAT", Road: 123, Mile1: 8, Mile2: 9, Timestamp1: 0, Timestamp2: 45, Speed: 8000}
 	AssertTicket(t, reader, expectedTicket)
 }
 
@@ -150,7 +150,7 @@ func TestPlateRequest(t *testing.T) {
 	defer client.Disconnect()
 
 	client.SendIAMCamera(srv.Camera{Road: 20, Mile: 80, Limit: 100})
-	client.SendPlateRecord(srv.Plate{Plate: "UN1X", Timestamp: 1000})
+	client.SendPlateRecord(srv.Plate{Plate: "GJGJ", Timestamp: 1000})
 
 	time.Sleep(500 * time.Millisecond) // test ended before verifying
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of server requests, logging, and synchronization in various parts of the codebase. The most important changes include improvements to locking mechanisms, logging enhancements, and updates to error handling and test cases.

### Improvements to locking mechanisms:

* [`internal/camera.go`](diffhunk://#diff-9443396a6a767d619bf3e26fad2fdd7f9ce3f758d322c9a9f64e4a5ffd63eddaL42-R54): Adjusted the placement of `slock.Unlock()` to ensure proper synchronization when handling plate requests.
* [`internal/dispatcher.go`](diffhunk://#diff-e4d59454556d928fb2dea1fc558bd559d2a44855ec7d3bd741b0476dc31099b4R22-L24): Added `defer s.slock.Unlock()` to ensure the lock is properly released after handling dispatcher requests.
* [`internal/server.go`](diffhunk://#diff-2b0bf79e19fe4eb1540beb0b6d88642e3c87ab38de6103290a4e4f775e377173L20-R20): Changed `slock` from `sync.RWMutex` to `sync.Mutex` to simplify locking mechanisms.

### Logging enhancements:

* [`internal/camera.go`](diffhunk://#diff-9443396a6a767d619bf3e26fad2fdd7f9ce3f758d322c9a9f64e4a5ffd63eddaL42-R54): Updated log messages to include additional context such as road, mile, and limit for plate requests.
* [`internal/dispatcher.go`](diffhunk://#diff-e4d59454556d928fb2dea1fc558bd559d2a44855ec7d3bd741b0476dc31099b4L13-R13): Prefixed error messages with `[dispatcher]` for better log categorization.
* [`internal/speed_detection.go`](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dL26-R27): Improved log messages in speed violation handling to provide clearer information. [[1]](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dL26-R27) [[2]](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dL42-R43)

### Error handling improvements:

* [`internal/protocol.go`](diffhunk://#diff-ced8eb545a6b8312d9afc5adb906cda8f06385c2feb986191d4fcb929e4ceb7fL65-R65): Updated error message formatting in `ParseCameraRequest` to use `%v` instead of `%x` for better readability.
* [`internal/heartbeat.go`](diffhunk://#diff-017c12107f416d5aff3b96568a90cbf63bcaac1b283967e500913944b3c77001L12-L15): Removed redundant error check for unregistered clients in `WantHeatbeatHandler`.

### Test case updates:

* [`test/integration_test.go`](diffhunk://#diff-8118e44ac15fb5ab2e2ece2ab52fd23062a10b5cc9c55ee5b3620a1242cff27cL35-R35): Updated test cases to use different plate numbers and road values for better test coverage. [[1]](diffhunk://#diff-8118e44ac15fb5ab2e2ece2ab52fd23062a10b5cc9c55ee5b3620a1242cff27cL35-R35) [[2]](diffhunk://#diff-8118e44ac15fb5ab2e2ece2ab52fd23062a10b5cc9c55ee5b3620a1242cff27cL49-R49) [[3]](diffhunk://#diff-8118e44ac15fb5ab2e2ece2ab52fd23062a10b5cc9c55ee5b3620a1242cff27cL136-R143) [[4]](diffhunk://#diff-8118e44ac15fb5ab2e2ece2ab52fd23062a10b5cc9c55ee5b3620a1242cff27cL153-R153)

### Codebase simplification:

* [`internal/speed_detection.go`](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dL83-R80): Simplified the `isSpeedViolation` function by using `math.Abs` to calculate the distance between observations.
* [`internal/speed_detection.go`](diffhunk://#diff-099b976650200574824614872de5cdb0f1ea94be4412375a9a59b57c995aea3dL100-R107): Refactored `CheckTicketLimit` to be a method of `Server` and improved its logic for checking prior tickets.